### PR TITLE
joystick node added in simulation.launch file

### DIFF
--- a/tocabi_controller/launch/simulation.launch
+++ b/tocabi_controller/launch/simulation.launch
@@ -4,6 +4,7 @@
     <arg name="controller" default="true" />
     <arg name="log" default="false"/>
     <arg name="node_start_delay" default="0.2" />  
+    <arg name="joystick" default="false" /> 
 
     <node name="tocabi_controller_shm_reset" pkg="tocabi_controller" type="shm_reset" output="screen"/>
     
@@ -41,6 +42,15 @@
 
     <group if="$(arg gui)">
         <node name="tocabi_gui" pkg="tocabi_gui" type="tocabi_gui" />
+    </group>
+
+    <group if="$(arg joystick)">
+        <node name="joy_node" pkg="joy" type="joy_node" respawn="true">
+            <param name="dev" type="string" value="/dev/input/js0" />
+            <param name="deadzone" value="0.12" />
+            <param name="autorepeat_rate" value="20" />
+            <param name="coalesce_interval" value="0.05" />
+        </node>
     </group>
 
 </launch>


### PR DESCRIPTION
조이스틱 노드 추가.
런치파일 실행시 joystick:=true 옵션 (defalt = "false") 으로 ROS Joy_node 사용가능.
param도 지정가능하니 확인바람.