### PR TITLE
add launch file for running Joystick node only with parameters

### DIFF
--- a/tocabi_controller/launch/joystick_only.launch
+++ b/tocabi_controller/launch/joystick_only.launch
@@ -1,0 +1,13 @@
+<launch>
+    <arg name="joystick" default="true" /> 
+    
+    <group if="$(arg joystick)">
+        <node name="joy_node" pkg="joy" type="joy_node" respawn="true">
+            <param name="dev" type="string" value="/dev/input/js0" />
+            <param name="deadzone" value="0.12" />
+            <param name="autorepeat_rate" value="20" />
+            <param name="coalesce_interval" value="0.05" />
+        </node>
+    </group>
+
+</launch>

--- a/tocabi_controller/launch/simulation.launch
+++ b/tocabi_controller/launch/simulation.launch
@@ -4,6 +4,7 @@
     <arg name="controller" default="true" />
     <arg name="log" default="false"/>
     <arg name="node_start_delay" default="0.2" />  
+    <arg name="joystick" default="false" /> 
 
     <node name="tocabi_controller_shm_reset" pkg="tocabi_controller" type="shm_reset" output="screen"/>
     
@@ -41,6 +42,15 @@
 
     <group if="$(arg gui)">
         <node name="tocabi_gui" pkg="tocabi_gui" type="tocabi_gui" />
+    </group>
+
+    <group if="$(arg joystick)">
+        <node name="joy_node" pkg="joy" type="joy_node" respawn="true">
+            <param name="dev" type="string" value="/dev/input/js0" />
+            <param name="deadzone" value="0.12" />
+            <param name="autorepeat_rate" value="20" />
+            <param name="coalesce_interval" value="0.05" />
+        </node>
     </group>
 
 </launch>


### PR DESCRIPTION
launch file added from recent commit.
this launch file running only joystick node with parameters.



#### [Parameters](https://wiki.ros.org/joy)
###### ~dev (str, default: "/dev/input/js0")
Linux joystick device from which to read joystick events.
###### ~deadzone (double, default: 0.05)
Amount by which the joystick has to move before it is considered to be off-center. This parameter is specified relative to an axis normalized between -1 and 1. Thus, 0.1 means that the joystick has to move 10% of the way to the edge of an axis's range before that axis will output a non-zero value. Linux does its own deadzone processing, so in many cases this value can be set to zero.
###### ~autorepeat_rate (double, default: 0.0 (disabled))
Rate in Hz at which a joystick that has a non-changing state will resend the previously sent message.
###### ~coalesce_interval (double, default: 0.001)
Axis events that are received within coalesce_interval (seconds) of each other are sent out in a single ROS message. Since the kernel sends each axis motion as a separate event, coalescing greatly reduces the rate at which messages are sent. This option can also be used to limit the rate of outgoing messages. Button events are always sent out immediately to avoid missing button presses.
###### ~default_trig_val (bool, default: false)
When this parameter is false, each button and axis will report a value of 0 until it gets pressed/touched. This might be a problem e.g. for the trigger axes which should report 1.0 in their default untouched position. Setting this parameter to true forces the driver to read the actual joystick button values on startup and report the correct values even before the buttons/axes were touched. There is a small probability that reading out the initial state will not work for some combinations of gamepads and kernel versions, and that is why this parameter is false by default.
###### ~dev_ff (str, default: "/dev/input/event0" (New in Noetic: autodetection is tried if this parameter is not specified))
The device to use for accessing force feedback function. It is usually one of /dev/input/event* devices. You can use udevadm monitor command when plugging in the gamepad to tell the right event file name.
